### PR TITLE
ci: upgrade artifact actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           Compress-Archive -Path $env:APP -DestinationPath "$env:APP.zip"
           Compress-Archive -Path $env:CLI -DestinationPath "$env:CLI.zip"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.slug }}
           path: |
@@ -125,7 +125,7 @@ jobs:
           # symlinks and resource forks intact.
           ditto -c -k --sequesterRsrc --keepParent "$app" "$app.zip"
           ditto -c -k --sequesterRsrc --keepParent "$cli" "$cli.zip"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos
           path: "*.zip"
@@ -141,7 +141,7 @@ jobs:
           ref: ${{ env.TAG }}
           sparse-checkout: .github/release-notes.md
           sparse-checkout-cone-mode: false
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

- pin `actions/upload-artifact` to v7.0.1
- pin `actions/download-artifact` to v8.0.1
- remove the Node 20 deprecation warnings observed while publishing v1.5.0-rc.3

Both replacements use Node 24 and remain pinned to immutable commit SHAs.

## Verification

- release workflow YAML parses successfully
- v1.5.0-rc.4 will exercise upload and download end to end after merge
